### PR TITLE
parse csvs and create or update investment when a new csv is created

### DIFF
--- a/lib/investment_tracker/CSVs.ex
+++ b/lib/investment_tracker/CSVs.ex
@@ -4,19 +4,26 @@ defmodule InvestmentTracker.CSVs do
   """
 
   import Ecto.Query, warn: false
-  alias InvestmentTracker.Repo
 
   alias InvestmentTracker.CSVs.CSV
+  alias InvestmentTracker.CSVs.Parsers.Fundos
+  alias InvestmentTracker.CSVs.Parsers.RendaFixa
+  alias InvestmentTracker.CSVs.Parsers.RendaVariavel
+  alias InvestmentTracker.CSVs.Parsers.TesouroDireto
+  alias InvestmentTracker.Repo
+  alias InvestmentTracker.Wallet
+  alias InvestmentTracker.Wallet.Investment
 
   @doc """
   Returns the list of csvs.
 
   ## Examples
 
-      iex> list_csvs()
-      [%CSV{}, ...]
+  iex> list_csvs()
+  [%CSV{}, ...]
 
   """
+  @spec list_csvs :: [CSV.t()]
   def list_csvs do
     Repo.all(CSV)
   end
@@ -28,13 +35,14 @@ defmodule InvestmentTracker.CSVs do
 
   ## Examples
 
-      iex> get_csv!(123)
-      %CSV{}
+  iex> get_csv!(123)
+  %CSV{}
 
-      iex> get_csv!(456)
-      ** (Ecto.NoResultsError)
+  iex> get_csv!(456)
+  ** (Ecto.NoResultsError)
 
   """
+  @spec get_csv!(String.t()) :: CSV.t()
   def get_csv!(id), do: Repo.get!(CSV, id)
 
   @doc """
@@ -49,6 +57,7 @@ defmodule InvestmentTracker.CSVs do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec create_csv(map()) :: {:ok, CSV.t()} | {:error, Ecto.Changeset.t()}
   def create_csv(attrs \\ %{}) do
     %CSV{}
     |> CSV.changeset(attrs)
@@ -67,6 +76,7 @@ defmodule InvestmentTracker.CSVs do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec update_csv(CSV.t(), map()) :: {:ok, CSV.t()} | {:error, Ecto.Changeset.t()}
   def update_csv(%CSV{} = csv, attrs) do
     csv
     |> CSV.changeset(attrs)
@@ -85,9 +95,39 @@ defmodule InvestmentTracker.CSVs do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec delete_csv(CSV.t()) :: {:ok, CSV.t()} | {:error, Ecto.Changeset.t()}
   def delete_csv(%CSV{} = csv) do
     Repo.delete(csv)
   end
+
+  @doc """
+  Imports investment data from a CSV file by creating a CSV record and parsing its content.
+
+  The function accepts a map of CSV attributes, creates a CSV record, and then parses the CSV content to
+  extract investment information. It then saves the investments to the wallet using the Wallet.upsert_investment/1 function.
+
+  Args:
+    attrs: A map containing the CSV attributes.
+
+  Returns:
+    {:ok, [%Investment{}]} on success or {:error, %Ecto.Changeset{}} on failure.
+  """
+  @spec import_csv(map()) ::
+          {:ok, [{:ok, Investment.t()} | {:ok, {:updated, Investment.t()}}]}
+          | {:error, Ecto.Changeset.t()}
+  def import_csv(attrs \\ %{}) do
+    with {:ok, csv} <- create_csv(attrs),
+         investment_maps <- parse_csv(csv) do
+      Repo.transaction(fn ->
+        Enum.map(investment_maps, fn map -> Wallet.upsert_investment(map) end)
+      end)
+    end
+  end
+
+  defp parse_csv(%{type: :fundos} = csv), do: Fundos.parse_csv(csv)
+  defp parse_csv(%{type: :renda_fixa} = csv), do: RendaFixa.parse_csv(csv)
+  defp parse_csv(%{type: :renda_variavel} = csv), do: RendaVariavel.parse_csv(csv)
+  defp parse_csv(%{type: :tesouro_direto} = csv), do: TesouroDireto.parse_csv(csv)
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking csv changes.
@@ -98,6 +138,7 @@ defmodule InvestmentTracker.CSVs do
       %Ecto.Changeset{data: %CSV{}}
 
   """
+  @spec change_csv(map) :: Ecto.Changeset.t()
   def change_csv(%CSV{} = csv, attrs \\ %{}) do
     CSV.changeset(csv, attrs)
   end

--- a/lib/investment_tracker/wallet.ex
+++ b/lib/investment_tracker/wallet.ex
@@ -62,7 +62,7 @@ defmodule InvestmentTracker.Wallet do
              investment_id: investment.id,
              value: investment.current_value
            }) do
-      {:ok, investment}
+      {:ok, Repo.preload(investment, [:investment_histories])}
     else
       {:error, changeset} -> {:error, changeset}
       changeset -> {:error, changeset}
@@ -91,7 +91,7 @@ defmodule InvestmentTracker.Wallet do
              investment_id: investment.id,
              value: investment.current_value
            }) do
-      {:ok, investment}
+      {:ok, Repo.preload(investment, [:investment_histories])}
     else
       {:error, changeset} -> {:error, changeset}
       changeset -> {:error, changeset}

--- a/lib/investment_tracker/wallet.ex
+++ b/lib/investment_tracker/wallet.ex
@@ -8,6 +8,7 @@ defmodule InvestmentTracker.Wallet do
   alias InvestmentTracker.Repo
   alias InvestmentTracker.Wallet.Investment
   alias InvestmentTracker.Wallet.InvestmentHistory
+  alias InvestmentTracker.Wallet.Operation
 
   @doc """
   Returns the list of investments.
@@ -18,6 +19,7 @@ defmodule InvestmentTracker.Wallet do
       [%Investment{}, ...]
 
   """
+  @spec list_investments() :: list(Investment.t())
   def list_investments do
     Repo.all(Investment)
   end
@@ -36,6 +38,7 @@ defmodule InvestmentTracker.Wallet do
       ** (Ecto.NoResultsError)
 
   """
+  @spec get_investment!(integer()) :: Investment.t()
   def get_investment!(id), do: Repo.get!(Investment, id)
 
   @doc """
@@ -163,6 +166,7 @@ defmodule InvestmentTracker.Wallet do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec delete_investment(Investment.t()) :: {:ok, Investment.t()} | {:error, Ecto.Changeset.t()}
   def delete_investment(%Investment{} = investment) do
     Repo.delete(investment)
   end
@@ -172,25 +176,25 @@ defmodule InvestmentTracker.Wallet do
 
   ## Examples
 
-      iex> change_investment(investment)
-      %Ecto.Changeset{data: %Investment{}}
+  iex> change_investment(investment)
+  %Ecto.Changeset{data: %Investment{}}
 
   """
+  @spec change_investment(map, map) :: Ecto.Changeset.t()
   def change_investment(%Investment{} = investment, attrs \\ %{}) do
     Investment.changeset(investment, attrs)
   end
-
-  alias InvestmentTracker.Wallet.Operation
 
   @doc """
   Returns the list of operations.
 
   ## Examples
 
-      iex> list_operations()
-      [%Operation{}, ...]
+  iex> list_operations()
+  [%Operation{}, ...]
 
   """
+  @spec list_operations :: [Operation.t()]
   def list_operations do
     Repo.all(Operation)
   end
@@ -202,13 +206,14 @@ defmodule InvestmentTracker.Wallet do
 
   ## Examples
 
-      iex> get_operation!(123)
-      %Operation{}
+  iex> get_operation!(123)
+  %Operation{}
 
-      iex> get_operation!(456)
-      ** (Ecto.NoResultsError)
+  iex> get_operation!(456)
+  ** (Ecto.NoResultsError)
 
   """
+  @spec get_operation!(String.t()) :: Operation.t()
   def get_operation!(id), do: Repo.get!(Operation, id)
 
   @doc """
@@ -216,13 +221,14 @@ defmodule InvestmentTracker.Wallet do
 
   ## Examples
 
-      iex> create_operation(%{field: value})
-      {:ok, %Operation{}}
+  iex> create_operation(%{field: value})
+  {:ok, %Operation{}}
 
-      iex> create_operation(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
+  iex> create_operation(%{field: bad_value})
+  {:error, %Ecto.Changeset{}}
 
   """
+  @spec create_operation(map) :: {:ok, Operation.t()} | {:error, Ecto.Changeset.t()}
   def create_operation(attrs \\ %{}) do
     %Operation{}
     |> Operation.changeset(attrs)
@@ -234,13 +240,15 @@ defmodule InvestmentTracker.Wallet do
 
   ## Examples
 
-      iex> update_operation(operation, %{field: new_value})
-      {:ok, %Operation{}}
+  iex> update_operation(operation, %{field: new_value})
+  {:ok, %Operation{}}
 
-      iex> update_operation(operation, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
+  iex> update_operation(operation, %{field: bad_value})
+  {:error, %Ecto.Changeset{}}
 
   """
+  @spec update_operation(Operation.t(), map) ::
+          {:ok, Operation.t()} | {:error, Ecto.Changeset.t()}
   def update_operation(%Operation{} = operation, attrs) do
     operation
     |> Operation.changeset(attrs)
@@ -252,13 +260,13 @@ defmodule InvestmentTracker.Wallet do
 
   ## Examples
 
-      iex> delete_operation(operation)
-      {:ok, %Operation{}}
+  iex> delete_operation(operation)
+  {:ok, %Operation{}}
 
-      iex> delete_operation(operation)
-      {:error, %Ecto.Changeset{}}
-
+  iex> delete_operation(operation)
+  {:error, %Ecto.Changeset{}}
   """
+  @spec delete_operation(Operation.t()) :: {:ok, Operation.t()} | {:error, Ecto.Changeset.t()}
   def delete_operation(%Operation{} = operation) do
     Repo.delete(operation)
   end
@@ -268,10 +276,11 @@ defmodule InvestmentTracker.Wallet do
 
   ## Examples
 
-      iex> change_operation(operation)
-      %Ecto.Changeset{data: %Operation{}}
+  iex> change_operation(operation)
+  %Ecto.Changeset{data: %Operation{}}
 
   """
+  @spec change_operation(map, map) :: Ecto.Changeset.t()
   def change_operation(%Operation{} = operation, attrs \\ %{}) do
     Operation.changeset(operation, attrs)
   end

--- a/lib/investment_tracker/wallet/investment.ex
+++ b/lib/investment_tracker/wallet/investment.ex
@@ -35,6 +35,7 @@ defmodule InvestmentTracker.Wallet.Investment do
     investment
     |> cast(attrs, [:name, :type, :subtype, :initial_value, :current_value, :expiration_date])
     |> validate_required([:name, :type, :initial_value, :current_value])
+    |> unique_constraint(:name)
     |> validate_subtype()
   end
 

--- a/lib/investment_tracker/wallet/investment.ex
+++ b/lib/investment_tracker/wallet/investment.ex
@@ -17,6 +17,21 @@ defmodule InvestmentTracker.Wallet.Investment do
   @renda_variavel ~w(fiis)a
   @subtypes @renda_fixa ++ @fundos ++ @tesouro_direto ++ @renda_variavel
 
+  @typedoc """
+  Type representing the Investment struct.
+  """
+  @type t :: %__MODULE__{
+          id: binary(),
+          current_value: integer(),
+          expiration_date: Date.t() | nil,
+          initial_value: integer(),
+          name: String.t(),
+          subtype: atom(),
+          type: atom(),
+          investment_histories: [InvestmentTracker.Wallet.InvestmentHistory.t()] | nil,
+          operations: [InvestmentTracker.Wallet.Operation.t()] | nil
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "investments" do
@@ -26,6 +41,9 @@ defmodule InvestmentTracker.Wallet.Investment do
     field :name, :string
     field :subtype, Ecto.Enum, values: @subtypes
     field :type, Ecto.Enum, values: @types
+
+    has_many :investment_histories, InvestmentTracker.Wallet.InvestmentHistory
+    has_many :operations, InvestmentTracker.Wallet.Operation
 
     timestamps()
   end

--- a/lib/investment_tracker/wallet/investment_history.ex
+++ b/lib/investment_tracker/wallet/investment_history.ex
@@ -1,0 +1,36 @@
+defmodule InvestmentTracker.Wallet.InvestmentHistory do
+  @moduledoc """
+  This schema tracks the history of an investment's value.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias InvestmentTracker.Wallet.Investment
+
+  @typedoc """
+  Type representing the InvestmentHistory struct.
+  """
+  @type t :: %__MODULE__{
+          id: binary(),
+          value: integer(),
+          investment_id: binary(),
+          investment: Investment.t()
+        }
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "investment_histories" do
+    field :value, :integer
+
+    belongs_to :investment, Investment
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(investment_history, attrs) do
+    investment_history
+    |> cast(attrs, [:value, :investment_id])
+    |> validate_required([:value, :investment_id])
+    |> assoc_constraint(:investment)
+  end
+end

--- a/lib/investment_tracker/wallet/operation.ex
+++ b/lib/investment_tracker/wallet/operation.ex
@@ -24,7 +24,7 @@ defmodule InvestmentTracker.Wallet.Operation do
   @doc false
   def changeset(operation, attrs) do
     operation
-    |> cast(attrs, [:type, :value])
-    |> validate_required([:type, :value])
+    |> cast(attrs, [:type, :value, :investment_id])
+    |> validate_required([:type, :value, :investment_id])
   end
 end

--- a/lib/investment_tracker/wallet/operation.ex
+++ b/lib/investment_tracker/wallet/operation.ex
@@ -8,15 +8,28 @@ defmodule InvestmentTracker.Wallet.Operation do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  alias InvestmentTracker.Wallet.Investment
 
   @types ~w(deposit withdraw update)a
+
+  @typedoc """
+  Type representing the Operation struct.
+  """
+  @type t :: %__MODULE__{
+          id: binary(),
+          type: atom(),
+          value: integer(),
+          investment_id: binary(),
+          investment: Investment.t()
+        }
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "operations" do
     field :type, Ecto.Enum, values: @types
     field :value, :integer
-    field :investment_id, :binary_id
+
+    belongs_to :investment, Investment
 
     timestamps()
   end
@@ -26,5 +39,6 @@ defmodule InvestmentTracker.Wallet.Operation do
     operation
     |> cast(attrs, [:type, :value, :investment_id])
     |> validate_required([:type, :value, :investment_id])
+    |> assoc_constraint(:investment)
   end
 end

--- a/priv/repo/migrations/20230404160450_add_unique_constraint_to_investments_name.exs
+++ b/priv/repo/migrations/20230404160450_add_unique_constraint_to_investments_name.exs
@@ -1,0 +1,8 @@
+defmodule InvestmentTracker.Repo.Migrations.AddUniqueConstraintToInvestmentsName do
+  @moduledoc false
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:investments, [:name])
+  end
+end

--- a/priv/repo/migrations/20230408190312_create_investment_histories.exs
+++ b/priv/repo/migrations/20230408190312_create_investment_histories.exs
@@ -1,0 +1,17 @@
+defmodule InvestmentTracker.Repo.Migrations.CreateInvestmentHistories do
+  use Ecto.Migration
+
+  def change do
+    create table(:investment_histories, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :value, :integer, null: false
+
+      add :investment_id, references(:investments, on_delete: :nothing, type: :binary_id),
+        null: false
+
+      timestamps()
+    end
+
+    create index(:investment_histories, [:investment_id])
+  end
+end

--- a/test/investment_tracker/CSVs_test.exs
+++ b/test/investment_tracker/CSVs_test.exs
@@ -526,5 +526,275 @@ defmodule InvestmentTracker.CSVsTest do
 
       assert [_csv1, _csv2] = Repo.all(CSV)
     end
+
+    test "import_csv/1 successfully imports investments from a renda fixa CSV" do
+      attrs = params_for(:renda_fixa_csv)
+
+      assert {
+               :ok,
+               [
+                 ok: %Investment{
+                   current_value: 336_524,
+                   id: id_1,
+                   initial_value: 311_729,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_1,
+                       value: 336_524
+                     }
+                   ],
+                   name: "LCI MNO",
+                   subtype: :lci_lca,
+                   type: :renda_fixa,
+                   expiration_date: ~D[2023-08-11]
+                 },
+                 ok: %Investment{
+                   current_value: 329_238,
+                   id: id_2,
+                   initial_value: 311_214,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_2,
+                       value: 329_238
+                     }
+                   ],
+                   name: "LCA XYZ",
+                   subtype: :lci_lca,
+                   type: :renda_fixa,
+                   expiration_date: ~D[2023-08-12]
+                 },
+                 ok: %Investment{
+                   current_value: 573_425,
+                   id: id_3,
+                   initial_value: 557_361,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_3,
+                       value: 573_425
+                     }
+                   ],
+                   name: "DEBENTURE LIGHB6",
+                   subtype: :debentures,
+                   type: :renda_fixa,
+                   expiration_date: ~D[2025-10-17]
+                 },
+                 ok: %Investment{
+                   current_value: 203_456,
+                   id: id_4,
+                   initial_value: 290_034,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_4,
+                       value: 203_456
+                     }
+                   ],
+                   name: "CRI STRAIGHTS175E2",
+                   subtype: :cri_cra,
+                   type: :renda_fixa,
+                   expiration_date: ~D[2024-11-20]
+                 },
+                 ok: %Investment{
+                   current_value: 112_830,
+                   id: id_5,
+                   initial_value: 107_825,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_5,
+                       value: 112_830
+                     }
+                   ],
+                   name: "CRA GREEN130S2",
+                   subtype: :cri_cra,
+                   type: :renda_fixa,
+                   expiration_date: ~D[2029-07-17]
+                 },
+                 ok: %Investment{
+                   current_value: 1_231_149,
+                   id: id_6,
+                   initial_value: 1_200_000,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_6,
+                       value: 1_231_149
+                     }
+                   ],
+                   name: "CDB LIMIT PLUS",
+                   subtype: :cdb,
+                   type: :renda_fixa,
+                   expiration_date: ~D[2026-01-01]
+                 },
+                 ok: %Investment{
+                   current_value: 121_921,
+                   id: id_7,
+                   initial_value: 105_000,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_7,
+                       value: 121_921
+                     }
+                   ],
+                   name: "CDB YZC",
+                   subtype: :cdb,
+                   type: :renda_fixa,
+                   expiration_date: ~D[2024-01-01]
+                 }
+               ]
+             } = CSVs.import_csv(attrs)
+
+      assert [_csv] = Repo.all(CSV)
+    end
+
+    test "import_csv/1 successfully imports investments from a renda variavel CSV" do
+      attrs = params_for(:renda_variavel_csv)
+
+      assert {
+               :ok,
+               [
+                 ok: %Investment{
+                   current_value: 60_450,
+                   id: id_1,
+                   initial_value: 63_300,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_1,
+                       value: 60_450
+                     }
+                   ],
+                   name: "ANON01",
+                   subtype: :fiis,
+                   type: :renda_variavel
+                 },
+                 ok: %Investment{
+                   current_value: 44_000,
+                   id: id_2,
+                   initial_value: 52_000,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_2,
+                       value: 44_000
+                     }
+                   ],
+                   name: "ANON02",
+                   subtype: :fiis,
+                   type: :renda_variavel
+                 },
+                 ok: %Investment{
+                   current_value: 56_000,
+                   id: id_3,
+                   initial_value: 62_400,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_3,
+                       value: 56_000
+                     }
+                   ],
+                   name: "ANON03",
+                   subtype: :fiis,
+                   type: :renda_variavel
+                 },
+                 ok: %Investment{
+                   current_value: 49_350,
+                   id: id_4,
+                   initial_value: 56_700,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_4,
+                       value: 49_350
+                     }
+                   ],
+                   name: "ANON04",
+                   subtype: :fiis,
+                   type: :renda_variavel
+                 },
+                 ok: %Investment{
+                   current_value: 58_800,
+                   id: id_5,
+                   initial_value: 59_500,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_5,
+                       value: 58_800
+                     }
+                   ],
+                   name: "ANON05",
+                   subtype: :fiis,
+                   type: :renda_variavel
+                 },
+                 ok: %Investment{
+                   current_value: 51_000,
+                   id: id_6,
+                   initial_value: 60_600,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_6,
+                       value: 51_000
+                     }
+                   ],
+                   name: "ANON06",
+                   subtype: :fiis,
+                   type: :renda_variavel
+                 }
+               ]
+             } = CSVs.import_csv(attrs)
+
+      assert [_csv] = Repo.all(CSV)
+    end
+
+    test "import_csv/1 successfully imports investments from a tesouro direto CSV" do
+      attrs = params_for(:tesouro_direto_csv)
+
+      assert {
+               :ok,
+               [
+                 ok: %Investment{
+                   current_value: 2_676_504,
+                   id: id_1,
+                   initial_value: 2_443_023,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_1,
+                       value: 2_676_504
+                     }
+                   ],
+                   name: "Tesouro Selic 2025",
+                   subtype: :selic,
+                   type: :tesouro_direto,
+                   expiration_date: ~D[2025-03-01]
+                 },
+                 ok: %Investment{
+                   current_value: 3_490_543,
+                   id: id_2,
+                   initial_value: 3_123_456,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_2,
+                       value: 3_490_543
+                     }
+                   ],
+                   name: "Tesouro Prefixado 2029",
+                   subtype: :prefixado,
+                   type: :tesouro_direto,
+                   expiration_date: ~D[2029-12-01]
+                 },
+                 ok: %Investment{
+                   current_value: 6_123_456,
+                   id: id_3,
+                   initial_value: 5_543_212,
+                   investment_histories: [
+                     %InvestmentHistory{
+                       investment_id: id_3,
+                       value: 6_123_456
+                     }
+                   ],
+                   name: "Tesouro IPCA+ Com Juros Semestrais 2032",
+                   subtype: :ipca,
+                   type: :tesouro_direto,
+                   expiration_date: ~D[2032-08-15]
+                 }
+               ]
+             } = CSVs.import_csv(attrs)
+
+      assert [_csv] = Repo.all(CSV)
+    end
   end
 end

--- a/test/investment_tracker/CSVs_test.exs
+++ b/test/investment_tracker/CSVs_test.exs
@@ -6,6 +6,9 @@ defmodule InvestmentTracker.CSVsTest do
 
   alias InvestmentTracker.CSVs
   alias InvestmentTracker.CSVs.CSV
+  alias InvestmentTracker.Wallet.Investment
+  alias InvestmentTracker.Wallet.InvestmentHistory
+  alias InvestmentTracker.Wallet.Operation
 
   describe "csvs" do
     @invalid_attrs %{content: nil, title: nil, type: nil}
@@ -63,6 +66,465 @@ defmodule InvestmentTracker.CSVsTest do
     test "change_csv/1 returns a csv changeset" do
       csv = insert(:csv)
       assert %Ecto.Changeset{} = CSVs.change_csv(csv)
+    end
+  end
+
+  describe "import csv" do
+    test "import_csv/1 successfully imports investments from a fundos CSV" do
+      attrs = params_for(:fundos_csv)
+
+      assert {
+               :ok,
+               [
+                 {:ok,
+                  %Investment{
+                    id: id_1,
+                    current_value: 689_292,
+                    initial_value: 646_965,
+                    name: "ANON ACCESS ABC CAPITAL FIM",
+                    subtype: :multimercado,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 689_292,
+                        investment_id: id_1
+                      }
+                    ]
+                  }},
+                 {:ok,
+                  %Investment{
+                    id: id_2,
+                    current_value: 500_796,
+                    initial_value: 500_000,
+                    name: "DAICHI KARAZUNO FIC FIM CP",
+                    subtype: :multimercado,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 500_796,
+                        investment_id: id_2
+                      }
+                    ]
+                  }},
+                 {:ok,
+                  %Investment{
+                    id: id_3,
+                    current_value: 202_163,
+                    initial_value: 200_000,
+                    name: "ANON ACCESS TRIGONOMETRY BS FIC FIM",
+                    subtype: :multimercado,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 202_163,
+                        investment_id: id_3
+                      }
+                    ]
+                  }},
+                 {:ok,
+                  %Investment{
+                    id: id_4,
+                    current_value: 522_196,
+                    initial_value: 538_799,
+                    name: "CALIFORNIAN WHATEVER US INDEX 500 FIM",
+                    subtype: :multimercado,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 522_196,
+                        investment_id: id_4
+                      }
+                    ]
+                  }},
+                 {:ok,
+                  %Investment{
+                    id: id_5,
+                    current_value: 5705,
+                    initial_value: 5702,
+                    name: "ANON RENDA AMAZING FIRF LP",
+                    subtype: :renda_fixa,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 5705,
+                        investment_id: id_5
+                      }
+                    ]
+                  }},
+                 {:ok,
+                  %Investment{
+                    id: id_6,
+                    current_value: 518_714,
+                    initial_value: 494_986,
+                    name: "CUTE HAMTARO STH FIC FIM",
+                    subtype: :multimercado,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 518_714,
+                        investment_id: id_6
+                      }
+                    ]
+                  }},
+                 {:ok,
+                  %Investment{
+                    id: id_8,
+                    current_value: 151_657,
+                    initial_value: 150_000,
+                    name: "ANON RENDA FIRF CP",
+                    subtype: :renda_fixa,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 151_657,
+                        investment_id: id_8
+                      }
+                    ]
+                  }},
+                 {:ok,
+                  %Investment{
+                    id: id_9,
+                    current_value: 1_003_332,
+                    initial_value: 1_000_000,
+                    name: "ANON RARE FIRF CP",
+                    subtype: :renda_fixa,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 1_003_332,
+                        investment_id: id_9
+                      }
+                    ]
+                  }},
+                 {:ok,
+                  %Investment{
+                    id: id_10,
+                    current_value: 68_006,
+                    initial_value: 69_990,
+                    name: "ANON SELECTION MULTIESTRATEGIA FIC FIM",
+                    subtype: :multimercado,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 68_006,
+                        investment_id: id_10
+                      }
+                    ]
+                  }},
+                 {:ok,
+                  %Investment{
+                    id: id_11,
+                    current_value: 3_613_420,
+                    initial_value: 3_500_000,
+                    name: "ALPHA OMEGA GLOBAL FIC FIM",
+                    subtype: :multimercado,
+                    type: :fundos,
+                    investment_histories: [
+                      %InvestmentHistory{
+                        value: 3_613_420,
+                        investment_id: id_11
+                      }
+                    ]
+                  }}
+               ]
+             } = CSVs.import_csv(attrs)
+
+      assert [_csv] = Repo.all(CSV)
+    end
+
+    test "import_csv/1 successfully updates investments from a fundos CSV" do
+      attrs = params_for(:fundos_csv)
+
+      # create investments
+
+      CSVs.import_csv(attrs)
+
+      # update investments
+
+      content = """
+      "","","","","","","",""
+      "TABLE 1","","","","","","",""
+      "","","","","","","",""
+      "","","","ANON ACCESS","ABC CAPITAL","FIM","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "01/01/2023","5108.42276296","R $ 1,36241335","R $ 6.469,65","R $ 6.959,78","R $ 66,86","R $ 0,00","R $ 6.992,92"
+      "","","","","","","",""
+      "","","","","","","",""
+      "TABLE 2","","","","","","",""
+      "","","","","","","",""
+      "","","","DAICHI KARAZUNO","FIC FIM CP","","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "01/01/2023","3574.40272981","R $ 1,40170440","R $ 5.000,00","R $ 5.010,26","R $ 2,30","R $ 0,00","R $ 5.002,96"
+      "","","","","","","",""
+      "","","","","","","",""
+      "TABLE 3","","","","","","",""
+      "","","","","","","",""
+      "","","","ANON ACCESS","TRIGONOMETRY BS FIC","FIM","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "03/12/2022","1599.12639086","R $ 1,26813128","R $ 2.000,00","R $ 2.027,90","R $ 6,27","R $ 0,00","R $ 2.421,63"
+      "","","","","","","",""
+      "","","","","","","",""
+      "TABLE 4","","","","","","",""
+      "","","","","","","",""
+      "","","","CALIFORNIAN WHATEVER","US INDEX 500 FIM","","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "03/12/2022","1093.6281063","R $ 4,77489460","R $ 5.387,99","R $ 5.221,96","R $ 0,00","R $ 0,00","R $ 5.211,96"
+      "","","","","","","",""
+      "","","","","","","",""
+      "TABLE 5","","","","","","",""
+      "","","","","","","",""
+      "","","","ANON RENDA","AMAZING FIRF","LP","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "03/12/2022","15.73414415","R $ 3,63290045","R $ 57,02","R $ 57,16","R $ 0,00","R $ 0,11","R $ 77,05"
+      "","","","","","","",""
+      "","","","","","","",""
+      "TABLE 6","","","","","","",""
+      "","","","","","","",""
+      "","","","CUTE HAMTARO","STH FIC FIM","","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "03/12/2022","14.35224537","R $ 361,41645460","R $ 4.949,86","R $ 5.187,14","R $ 0,00","R $ 0,00","R $ 5.187,14"
+      "","","","","","","",""
+      "","","","","","","",""
+      "TABLE 7","","","","","","",""
+      "","","","","","","",""
+      "","","","ANON","RENDA FIRF CP","","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "03/12/2022","774.37288715","R $ 1,96464388","R $ 1.500,00","R $ 1.521,37","R $ 4,80","R $ 0,00","R $ 1.518,57"
+      "","","","","","","",""
+      "","","","","","","",""
+      "TABLE 8","","","","","","",""
+      "","","","","","","",""
+      "","","","ANON","RARE FIRF CP","","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "03/12/2022","7988.18764326","R $ 1,26025674","R $ 10.000,00","R $ 10.067,17","R $ 9,67","R $ 24,18","R $ 12.033,32"
+      "","","","","","","",""
+      "","","","","","","",""
+      "TABLE 9","","","","","","",""
+      "","","","","","","",""
+      "","","","ANON SELECTION","MULTIESTRATEGIA","FIC FIM","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "21/02/2022","582.76385774","R $ 1,16695240","R $ 699,90","R $ 680,06","R $ 0,00","R $ 0,00","R $ 680,06"
+      "","","","","","","",""
+      "","","","","","","",""
+      "TABLE 10","","","","","","",""
+      "","","","","","","",""
+      "","","","ALPHA OMEGA","GLOBAL FIC FIM","","",""
+      "Data Cotação","Qtde Cota","Valor Cota","Valor Aplicado","Valor Bruto","IR Previsto","IOF Previsto","Valor Liquido"
+      "08/11/2022","21994.01998227","R $ 1,66128320","R $ 35.000,00","R $ 36.538,29","R $ 329,28","R $ 784,81","R $ 36.134,20"
+      """
+
+      update_attrs = %{
+        content: content,
+        title: "Fundos",
+        type: :fundos
+      }
+
+      assert {
+               :ok,
+               [
+                 {:ok,
+                  {:updated,
+                   %Investment{
+                     id: id_1,
+                     current_value: 699_292,
+                     initial_value: 646_965,
+                     name: "ANON ACCESS ABC CAPITAL FIM",
+                     subtype: :multimercado,
+                     type: :fundos,
+                     investment_histories: [
+                       %InvestmentHistory{
+                         value: 689_292,
+                         investment_id: id_1
+                       },
+                       %InvestmentHistory{
+                         value: 699_292,
+                         investment_id: id_1
+                       }
+                     ]
+                   },
+                   %Operation{
+                     type: :update,
+                     value: 10_000,
+                     investment_id: id_1
+                   }}},
+                 {:ok,
+                  {:updated,
+                   %Investment{
+                     id: id_2,
+                     current_value: 500_296,
+                     initial_value: 500_000,
+                     name: "DAICHI KARAZUNO FIC FIM CP",
+                     subtype: :multimercado,
+                     type: :fundos,
+                     investment_histories: [
+                       %InvestmentHistory{
+                         value: 500_796,
+                         investment_id: id_2
+                       },
+                       %InvestmentHistory{
+                         value: 500_296,
+                         investment_id: id_2
+                       }
+                     ]
+                   },
+                   %Operation{
+                     type: :update,
+                     value: -500,
+                     investment_id: id_2
+                   }}},
+                 ok:
+                   {:updated,
+                    %Investment{
+                      id: id_3,
+                      current_value: 242_163,
+                      initial_value: 200_000,
+                      name: "ANON ACCESS TRIGONOMETRY BS FIC FIM",
+                      subtype: :multimercado,
+                      type: :fundos,
+                      investment_histories: [
+                        %InvestmentHistory{
+                          value: 202_163,
+                          investment_id: id_3
+                        },
+                        %InvestmentHistory{
+                          value: 242_163,
+                          investment_id: id_3
+                        }
+                      ]
+                    },
+                    %Operation{
+                      type: :update,
+                      value: 40_000,
+                      investment_id: id_3
+                    }},
+                 ok:
+                   {:updated,
+                    %Investment{
+                      id: id_4,
+                      current_value: 521_196,
+                      initial_value: 538_799,
+                      name: "CALIFORNIAN WHATEVER US INDEX 500 FIM",
+                      subtype: :multimercado,
+                      type: :fundos,
+                      investment_histories: [
+                        %InvestmentHistory{
+                          value: 522_196,
+                          investment_id: id_4
+                        },
+                        %InvestmentHistory{
+                          value: 521_196,
+                          investment_id: id_4
+                        }
+                      ]
+                    },
+                    %Operation{
+                      type: :update,
+                      value: -1000,
+                      investment_id: id_4
+                    }},
+                 ok:
+                   {:updated,
+                    %Investment{
+                      id: id_5,
+                      current_value: 7705,
+                      initial_value: 5702,
+                      name: "ANON RENDA AMAZING FIRF LP",
+                      subtype: :renda_fixa,
+                      type: :fundos,
+                      investment_histories: [
+                        %InvestmentHistory{
+                          value: 5705,
+                          investment_id: id_5
+                        },
+                        %InvestmentHistory{
+                          value: 7705,
+                          investment_id: id_5
+                        }
+                      ]
+                    },
+                    %Operation{
+                      type: :update,
+                      value: 2000,
+                      investment_id: id_5
+                    }},
+                 ok: %Investment{
+                   current_value: 518_714,
+                   id: _id_6,
+                   initial_value: 494_986,
+                   name: "CUTE HAMTARO STH FIC FIM",
+                   subtype: :multimercado,
+                   type: :fundos
+                 },
+                 ok:
+                   {:updated,
+                    %Investment{
+                      id: id_8,
+                      current_value: 151_857,
+                      initial_value: 150_000,
+                      name: "ANON RENDA FIRF CP",
+                      subtype: :renda_fixa,
+                      type: :fundos,
+                      investment_histories: [
+                        %InvestmentHistory{
+                          value: 151_657,
+                          investment_id: id_8
+                        },
+                        %InvestmentHistory{
+                          value: 151_857,
+                          investment_id: id_8
+                        }
+                      ]
+                    },
+                    %Operation{
+                      type: :update,
+                      value: 200,
+                      investment_id: id_8
+                    }},
+                 ok:
+                   {:updated,
+                    %Investment{
+                      id: id_9,
+                      current_value: 1_203_332,
+                      initial_value: 1_000_000,
+                      name: "ANON RARE FIRF CP",
+                      subtype: :renda_fixa,
+                      type: :fundos,
+                      investment_histories: [
+                        %InvestmentHistory{
+                          value: 1_003_332,
+                          investment_id: id_9
+                        },
+                        %InvestmentHistory{
+                          value: 1_203_332,
+                          investment_id: id_9
+                        }
+                      ]
+                    },
+                    %Operation{
+                      type: :update,
+                      value: 200_000,
+                      investment_id: id_9
+                    }},
+                 ok: %Investment{
+                   current_value: 68_006,
+                   id: _id_10,
+                   initial_value: 69_990,
+                   name: "ANON SELECTION MULTIESTRATEGIA FIC FIM",
+                   subtype: :multimercado,
+                   type: :fundos
+                 },
+                 ok: %Investment{
+                   current_value: 3_613_420,
+                   id: _id_11,
+                   initial_value: 3_500_000,
+                   name: "ALPHA OMEGA GLOBAL FIC FIM",
+                   subtype: :multimercado,
+                   type: :fundos
+                 }
+               ]
+             } = CSVs.import_csv(update_attrs)
+
+      assert [_csv1, _csv2] = Repo.all(CSV)
     end
   end
 end

--- a/test/investment_tracker/wallet_test.exs
+++ b/test/investment_tracker/wallet_test.exs
@@ -8,6 +8,10 @@ defmodule InvestmentTracker.WalletTest do
   alias InvestmentTracker.Wallet.Investment
   alias InvestmentTracker.Wallet.Operation
 
+  setup do
+    {:ok, investment: insert(:investment)}
+  end
+
   describe "investments" do
     @invalid_attrs %{
       current_value: nil,
@@ -18,13 +22,11 @@ defmodule InvestmentTracker.WalletTest do
       type: nil
     }
 
-    test "list_investments/0 returns all investments" do
-      investment = insert(:investment)
+    test "list_investments/0 returns all investments", %{investment: investment} do
       assert Wallet.list_investments() == [investment]
     end
 
-    test "get_investment!/1 returns the investment with given id" do
-      investment = insert(:investment)
+    test "get_investment!/1 returns the investment with given id", %{investment: investment} do
       assert Wallet.get_investment!(investment.id) == investment
     end
 
@@ -66,9 +68,9 @@ defmodule InvestmentTracker.WalletTest do
       assert %{subtype: ["is invalid for the selected type"]} = errors_on(changeset)
     end
 
-    test "update_investment/2 with invalid subtype returns error changeset" do
-      investment = insert(:investment)
-
+    test "update_investment/2 with invalid subtype returns error changeset", %{
+      investment: investment
+    } do
       update_attrs = %{
         current_value: 43,
         expiration_date: ~D[2023-03-28],
@@ -83,9 +85,7 @@ defmodule InvestmentTracker.WalletTest do
       assert %{subtype: ["is invalid for the selected type"]} = errors_on(changeset)
     end
 
-    test "update_investment/2 with valid data updates the investment" do
-      investment = insert(:investment)
-
+    test "update_investment/2 with valid data updates the investment", %{investment: investment} do
       update_attrs = %{
         current_value: 43,
         expiration_date: ~D[2023-03-28],
@@ -106,20 +106,19 @@ defmodule InvestmentTracker.WalletTest do
       assert investment.type == :renda_fixa
     end
 
-    test "update_investment/2 with invalid data returns error changeset" do
-      investment = insert(:investment)
+    test "update_investment/2 with invalid data returns error changeset", %{
+      investment: investment
+    } do
       assert {:error, %Ecto.Changeset{}} = Wallet.update_investment(investment, @invalid_attrs)
       assert investment == Wallet.get_investment!(investment.id)
     end
 
-    test "delete_investment/1 deletes the investment" do
-      investment = insert(:investment)
+    test "delete_investment/1 deletes the investment", %{investment: investment} do
       assert {:ok, %Investment{}} = Wallet.delete_investment(investment)
       assert_raise Ecto.NoResultsError, fn -> Wallet.get_investment!(investment.id) end
     end
 
-    test "change_investment/1 returns a investment changeset" do
-      investment = insert(:investment)
+    test "change_investment/1 returns a investment changeset", %{investment: investment} do
       assert %Ecto.Changeset{} = Wallet.change_investment(investment)
     end
   end
@@ -127,18 +126,18 @@ defmodule InvestmentTracker.WalletTest do
   describe "operations" do
     @invalid_attrs %{type: nil, value: nil}
 
-    test "list_operations/0 returns all operations" do
-      operation = insert(:operation)
+    test "list_operations/0 returns all operations", %{investment: investment} do
+      operation = insert(:operation, investment: investment)
       assert Wallet.list_operations() == [operation]
     end
 
-    test "get_operation!/1 returns the operation with given id" do
-      operation = insert(:operation)
+    test "get_operation!/1 returns the operation with given id", %{investment: investment} do
+      operation = insert(:operation, investment: investment)
       assert Wallet.get_operation!(operation.id) == operation
     end
 
-    test "create_operation/1 with valid data creates a operation" do
-      valid_attrs = %{type: :deposit, value: 42}
+    test "create_operation/1 with valid data creates a operation", %{investment: investment} do
+      valid_attrs = %{type: :deposit, value: 42, investment_id: investment.id}
 
       assert {:ok, %Operation{} = operation} = Wallet.create_operation(valid_attrs)
       assert operation.type == :deposit
@@ -149,8 +148,8 @@ defmodule InvestmentTracker.WalletTest do
       assert {:error, %Ecto.Changeset{}} = Wallet.create_operation(@invalid_attrs)
     end
 
-    test "update_operation/2 with valid data updates the operation" do
-      operation = insert(:operation)
+    test "update_operation/2 with valid data updates the operation", %{investment: investment} do
+      operation = insert(:operation, investment: investment)
       update_attrs = %{type: :withdraw, value: 43}
 
       assert {:ok, %Operation{} = operation} = Wallet.update_operation(operation, update_attrs)
@@ -158,20 +157,20 @@ defmodule InvestmentTracker.WalletTest do
       assert operation.value == 43
     end
 
-    test "update_operation/2 with invalid data returns error changeset" do
-      operation = insert(:operation)
+    test "update_operation/2 with invalid data returns error changeset", %{investment: investment} do
+      operation = insert(:operation, investment: investment)
       assert {:error, %Ecto.Changeset{}} = Wallet.update_operation(operation, @invalid_attrs)
       assert operation == Wallet.get_operation!(operation.id)
     end
 
-    test "delete_operation/1 deletes the operation" do
-      operation = insert(:operation)
+    test "delete_operation/1 deletes the operation", %{investment: investment} do
+      operation = insert(:operation, investment: investment)
       assert {:ok, %Operation{}} = Wallet.delete_operation(operation)
       assert_raise Ecto.NoResultsError, fn -> Wallet.get_operation!(operation.id) end
     end
 
-    test "change_operation/1 returns a operation changeset" do
-      operation = insert(:operation)
+    test "change_operation/1 returns a operation changeset", %{investment: investment} do
+      operation = insert(:operation, investment: investment)
       assert %Ecto.Changeset{} = Wallet.change_operation(operation)
     end
   end

--- a/test/investment_tracker_web/controllers/operation_controller_test.exs
+++ b/test/investment_tracker_web/controllers/operation_controller_test.exs
@@ -4,9 +4,16 @@ defmodule InvestmentTrackerWeb.OperationControllerTest do
 
   import InvestmentTracker.Factory
 
-  @create_attrs %{type: :deposit, value: 42}
-  @update_attrs %{type: :deposit, value: 43}
-  @invalid_attrs %{type: nil, value: nil}
+  @investment_id Ecto.UUID.generate()
+  @create_attrs %{type: :deposit, value: 42, investment_id: @investment_id}
+  @update_attrs %{type: :deposit, value: 43, investment_id: @investment_id}
+  @invalid_attrs %{type: nil, value: nil, investment_id: @investment_id}
+
+  setup do
+    insert(:investment, id: @investment_id)
+
+    :ok
+  end
 
   describe "index" do
     test "lists all operations", %{conn: conn} do
@@ -79,7 +86,8 @@ defmodule InvestmentTrackerWeb.OperationControllerTest do
   end
 
   defp create_operation(_) do
-    operation = insert(:operation)
+    investment = insert(:investment)
+    operation = insert(:operation, investment: investment)
     %{operation: operation}
   end
 end

--- a/test/support/factory/CSVs.ex
+++ b/test/support/factory/CSVs.ex
@@ -7,6 +7,7 @@ defmodule InvestmentTracker.Factory.CSVs do
     quote do
       def csv_factory do
         %CSV{
+          id: Ecto.UUID.generate(),
           content: "some content",
           title: "some title",
           type: :renda_fixa,

--- a/test/support/factory/wallet.ex
+++ b/test/support/factory/wallet.ex
@@ -1,6 +1,7 @@
 defmodule InvestmentTracker.Factory.Wallet do
   @moduledoc false
   alias InvestmentTracker.Wallet.Investment
+  alias InvestmentTracker.Wallet.InvestmentHistory
   alias InvestmentTracker.Wallet.Operation
 
   defmacro __using__(_opts) do
@@ -23,6 +24,18 @@ defmodule InvestmentTracker.Factory.Wallet do
         %Operation{
           id: Ecto.UUID.generate(),
           type: :deposit,
+          value: 42,
+          investment_id: investment.id
+        }
+        |> merge_attributes(attrs)
+        |> evaluate_lazy_attributes()
+      end
+
+      def investment_history_factory(attrs \\ %{}) do
+        {investment, attrs} = Map.pop(attrs, :investment, build(:investment))
+
+        %InvestmentHistory{
+          id: Ecto.UUID.generate(),
           value: 42,
           investment_id: investment.id
         }

--- a/test/support/factory/wallet.ex
+++ b/test/support/factory/wallet.ex
@@ -7,6 +7,7 @@ defmodule InvestmentTracker.Factory.Wallet do
     quote do
       def investment_factory do
         %Investment{
+          id: Ecto.UUID.generate(),
           current_value: 42,
           expiration_date: ~D[2023-03-27],
           initial_value: 42,
@@ -20,6 +21,7 @@ defmodule InvestmentTracker.Factory.Wallet do
         {investment, attrs} = Map.pop(attrs, :investment, build(:investment))
 
         %Operation{
+          id: Ecto.UUID.generate(),
           type: :deposit,
           value: 42,
           investment_id: investment.id

--- a/test/support/factory/wallet.ex
+++ b/test/support/factory/wallet.ex
@@ -10,7 +10,7 @@ defmodule InvestmentTracker.Factory.Wallet do
           current_value: 42,
           expiration_date: ~D[2023-03-27],
           initial_value: 42,
-          name: "some name",
+          name: "some name #{Enum.random(?a..?z)}",
           subtype: :cdb,
           type: :renda_fixa
         }


### PR DESCRIPTION
- make name of investment unique
- make investment_id a required field for operations
- upsert investment
- add relations and type definitions to investment and operation
- add investment histories
- add specs to wallet module
- import csvs
